### PR TITLE
Chanange unauthorized redirect

### DIFF
--- a/ckanext/drupal8/plugin.py
+++ b/ckanext/drupal8/plugin.py
@@ -169,7 +169,7 @@ class Drupal8Plugin(p.SingletonPlugin):
         # been logged in yet.
         # self.identify()
         if (status_code == 401 and p.toolkit.c.user is not None):
-            h.redirect_to('drupal7_unauthorized')
+            h.redirect_to('drupal8_unauthorized')
         return (status_code, detail, headers, comment)
 
     def get_auth_functions(self):


### PR DESCRIPTION
- Unauthorized redirect was refering to drupal 7 instead of 8.